### PR TITLE
Python 3.5.3 is required, and enabled python3 on travisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 dist: trusty
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 env:
-  - AIOHTTP="2"
-  - AIOHTTP="1"
+  - AIOHTTP="3"
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - pip install -U setuptools
   - pip install -U pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    py3{4,5,6}-aiohttp{1,2}
+    py3{5,6}-aiohttp3
 skip_missing_interpreters = True
 
 [testenv]
 deps =
-    aiohttp1: aiohttp>=1.3.0,<2.0.0
-    aiohttp2: aiohttp>=2.2.3
+    aiohttp>=3.0.0
     pytest
     pytest-cov
     flake8


### PR DESCRIPTION
I accidentally pushed both #6 and #5 to #6, so I closed it and created this instead.
I've now properly fixed Python 3.7 on travisCI.

TravisCI tests were failing as python 3.5.3 is required, so 3.4 is no longer supported.

The official workaround for using python3.7 on travisCI is to enable sudo and use xenial.

Signed-off-by: Even Thomassen <even.thomassen@noriginmedia.com>